### PR TITLE
Removed un-needed whitespace in undo command message

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
@@ -315,7 +315,7 @@ public class Sniper {
                     break;
                 }
             }
-            getPlayer().sendMessage(ChatColor.GREEN + "Undo successful:  " + ChatColor.RED + sum + ChatColor.GREEN + " blocks have been replaced.");
+            getPlayer().sendMessage(ChatColor.GREEN + "Undo successful: " + ChatColor.RED + sum + ChatColor.GREEN + " blocks have been replaced.");
         }
     }
 


### PR DESCRIPTION
Basically what title says. I removed a space from the message when you use /u
Message looks a lot better now :-)